### PR TITLE
Feat/make-medium-user-optional

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -9,42 +9,46 @@ const client = contentful.createClient({
   accessToken: ACCESS_TOKEN,
 });
 
-module.exports = client.getEntries().then(entries => {
-  const aboutEntry = entries.items.find(
-    entry => entry.sys.contentType.sys.id === 'about',
-  );
+const getAboutContentType = entry => entry.sys.contentType.sys.id === 'about';
 
-  const about = aboutEntry.fields;
+module.exports = client.getEntries().then(entries => {
+  const aboutEntry = entries.items.find(getAboutContentType);
+
+  const plugins = [
+    'gatsby-plugin-react-helmet',
+    {
+      resolve: 'gatsby-plugin-manifest',
+      options: manifestConfig,
+    },
+    'gatsby-plugin-styled-components',
+    {
+      resolve: 'gatsby-plugin-google-fonts',
+      options: {
+        fonts: ['cabin', 'Open Sans'],
+      },
+    },
+    {
+      resolve: 'gatsby-source-contentful',
+      options: {
+        spaceId: SPACE_ID,
+        accessToken: ACCESS_TOKEN,
+      },
+    },
+    'gatsby-transformer-remark',
+    'gatsby-plugin-offline',
+  ];
+
+  // const { mediumUser } = aboutEntry.fields;
+  // if (mediumUser) {
+  plugins.push({
+    resolve: 'gatsby-source-medium',
+    options: {
+      username: aboutEntry.fields.mediumUser || '@medium',
+    },
+  });
+  // }
 
   return {
-    plugins: [
-      'gatsby-plugin-react-helmet',
-      {
-        resolve: 'gatsby-plugin-manifest',
-        options: manifestConfig,
-      },
-      'gatsby-plugin-styled-components',
-      {
-        resolve: `gatsby-plugin-google-fonts`,
-        options: {
-          fonts: [`cabin`, `Open Sans`],
-        },
-      },
-      {
-        resolve: `gatsby-source-contentful`,
-        options: {
-          spaceId: SPACE_ID,
-          accessToken: ACCESS_TOKEN,
-        },
-      },
-      {
-        resolve: `gatsby-source-medium`,
-        options: {
-          username: about.mediumUser,
-        },
-      },
-      'gatsby-transformer-remark',
-      'gatsby-plugin-offline',
-    ],
+    plugins,
   };
 });

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -9,46 +9,42 @@ const client = contentful.createClient({
   accessToken: ACCESS_TOKEN,
 });
 
-const getAboutContentType = entry => entry.sys.contentType.sys.id === 'about';
-
 module.exports = client.getEntries().then(entries => {
-  const aboutEntry = entries.items.find(getAboutContentType);
+  const aboutEntry = entries.items.find(
+    entry => entry.sys.contentType.sys.id === 'about',
+  );
 
-  const plugins = [
-    'gatsby-plugin-react-helmet',
-    {
-      resolve: 'gatsby-plugin-manifest',
-      options: manifestConfig,
-    },
-    'gatsby-plugin-styled-components',
-    {
-      resolve: 'gatsby-plugin-google-fonts',
-      options: {
-        fonts: ['cabin', 'Open Sans'],
-      },
-    },
-    {
-      resolve: 'gatsby-source-contentful',
-      options: {
-        spaceId: SPACE_ID,
-        accessToken: ACCESS_TOKEN,
-      },
-    },
-    'gatsby-transformer-remark',
-    'gatsby-plugin-offline',
-  ];
-
-  // const { mediumUser } = aboutEntry.fields;
-  // if (mediumUser) {
-  plugins.push({
-    resolve: 'gatsby-source-medium',
-    options: {
-      username: aboutEntry.fields.mediumUser || '@medium',
-    },
-  });
-  // }
+  const { mediumUser = '@medium' } = aboutEntry.fields;
 
   return {
-    plugins,
+    plugins: [
+      'gatsby-plugin-react-helmet',
+      {
+        resolve: 'gatsby-plugin-manifest',
+        options: manifestConfig,
+      },
+      'gatsby-plugin-styled-components',
+      {
+        resolve: 'gatsby-plugin-google-fonts',
+        options: {
+          fonts: ['cabin', 'Open Sans'],
+        },
+      },
+      {
+        resolve: 'gatsby-source-contentful',
+        options: {
+          spaceId: SPACE_ID,
+          accessToken: ACCESS_TOKEN,
+        },
+      },
+      {
+        resolve: 'gatsby-source-medium',
+        options: {
+          username: mediumUser,
+        },
+      },
+      'gatsby-transformer-remark',
+      'gatsby-plugin-offline',
+    ],
   };
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-starter-mate",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Gatsby v2 starter to create a top notch portfolio!",
   "main": "index.js",
   "scripts": {

--- a/src/sections/Writing.js
+++ b/src/sections/Writing.js
@@ -99,47 +99,54 @@ const parsePost = postFromGraphql => {
 const edgeToArray = data => data.edges.map(edge => edge.node);
 
 const Writing = () => (
-  <Section.Container id="writing" Background={Background}>
-    <Section.Header name="Writing" icon="✍️" label="writing" />
-    <StaticQuery
-      query={graphql`
-        query MediumPostQuery {
-          allMediumPost(limit: 6, sort: { fields: createdAt, order: DESC }) {
-            edges {
-              node {
-                id
-                uniqueSlug
-                title
-                createdAt(formatString: "MMM YYYY")
-                virtuals {
-                  subtitle
-                  readingTime
-                  previewImage {
-                    imageId
-                  }
+  <StaticQuery
+    query={graphql`
+      query MediumPostQuery {
+        isMediumUserDefine: __type(
+          name: "contentfulAboutMediumUserQueryString_2"
+        ) {
+          name
+        }
+        allMediumPost(limit: 6, sort: { fields: createdAt, order: DESC }) {
+          edges {
+            node {
+              id
+              uniqueSlug
+              title
+              createdAt(formatString: "MMM YYYY")
+              virtuals {
+                subtitle
+                readingTime
+                previewImage {
+                  imageId
                 }
-                author {
-                  username
-                }
+              }
+              author {
+                username
               }
             }
           }
         }
-      `}
-      render={({ allMediumPost }) => {
-        const posts = edgeToArray(allMediumPost).map(parsePost);
-        return (
-          <CardContainer minWidth="300px">
-            {posts.map(p => (
-              <Fade bottom>
-                <Post key={p.id} {...p} />
-              </Fade>
-            ))}
-          </CardContainer>
-        );
-      }}
-    />
-  </Section.Container>
+      }
+    `}
+    render={({ allMediumPost, isMediumUserDefine }) => {
+      const posts = edgeToArray(allMediumPost).map(parsePost);
+      return (
+        isMediumUserDefine && (
+          <Section.Container id="writing" Background={Background}>
+            <Section.Header name="Writing" icon="✍️" label="writing" />
+            <CardContainer minWidth="300px">
+              {posts.map(p => (
+                <Fade bottom>
+                  <Post key={p.id} {...p} />
+                </Fade>
+              ))}
+            </CardContainer>
+          </Section.Container>
+        )
+      );
+    }}
+  />
 );
 
 export default Writing;


### PR DESCRIPTION
## What is this pr about? 🤔
Make the starter compatible with empty `mediumUser` from About information

## Changes 🧳
- Make default userName to `@medium`
- Check if inside the `schema` of the `contentfulAbout` is define the value of `mediumUser`, otherwise the whole section of Writing return `false` on render.

Sadly this is just a patch, I tried to make this feature as dynamically as possible, for example by asking if the `mediumUser` is defined in About then don't add the plugin of `gatsby-source-medium`. But then the problem is that the `StaticQuery` inside `Writing` tries to query `allMediumPost` that it's not defined in the schema anymore ... 

I'm super open to try another alternative, but for now this works :)  
