### PR TITLE
fix: gatsby-medium-source patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "description": "Gatsby v2 starter to create a top notch portfolio!",
   "main": "index.js",
   "scripts": {
-    "build": "gatsby clean && gatsby build",
-    "develop": "gatsby clean && gatsby develop",
+    "medium-patch": "node patch-gatsby-source",
+    "build": "npm run medium-patch && gatsby clean && gatsby build",
+    "develop": "npm run medium-patch && gatsby clean && gatsby develop",
     "start": "npm run develop",
     "serve": "gatsby serve",
     "lint": "eslint ./src",

--- a/patch-gatsby-source.js
+++ b/patch-gatsby-source.js
@@ -1,0 +1,6 @@
+const fs = require('fs');
+
+const FILE_PATH = './node_modules/gatsby-source-medium/gatsby-node.js';
+
+const content = fs.readFileSync(FILE_PATH, 'utf8');
+fs.writeFileSync(FILE_PATH, content.replace(/latest/g, ''), 'utf8');

--- a/patch-gatsby-source.js
+++ b/patch-gatsby-source.js
@@ -1,3 +1,4 @@
+// TODO: This patch is needed until this issue is solved --> https://github.com/gatsbyjs/gatsby/issues/17335
 const fs = require('fs');
 
 const FILE_PATH = './node_modules/gatsby-source-medium/gatsby-node.js';


### PR DESCRIPTION
## What is this pr about? 👀

Fix build by removing `/latest` from the URL which doesn't require Authentication. 

## Some comments

* This will reduce the amount of posts that you can query from the medium API.